### PR TITLE
Permit per-file build targets.

### DIFF
--- a/codeblocks_cbp.lua
+++ b/codeblocks_cbp.lua
@@ -219,6 +219,9 @@
 					_p(3,'<Option weight="0" />')
 					_p(3,'<Add option="-x c++-header" />')
 				end
+				for k,fsub in pairs(node.configs) do
+					_p(3, '<Option target="%s" />', fsub.config.longname)
+				end
 				_p(2,'</Unit>')
 
 			end,


### PR DESCRIPTION
A file is not always in every configurations. This allows to generate the required C::B Option in each file.