### PR TITLE
Fixes to the Codeblocks module

### DIFF
--- a/codeblocks.lua
+++ b/codeblocks.lua
@@ -45,7 +45,7 @@
 		p.eol("\r\n")
 		p.indent("\t")
 		p.escaper(codeblocks.esc)
-		if project.iscpp(prj) then
+		if project.isc(prj) or project.iscpp(prj) then
 			p.generate(prj, ".cbp", codeblocks.project.generate)
 		end
 	end

--- a/codeblocks_cbp.lua
+++ b/codeblocks_cbp.lua
@@ -205,7 +205,7 @@
 				if node.relpath == node.vpath then
 					_p(2,'<Unit filename="%s">', node.relpath)
 				else
-					_p(2,'<Unit filename="%s">', node.name)
+					_p(2,'<Unit filename="%s">', node.relpath)
 					_p(3,'<Option virtualFolder="%s" />', path.getdirectory(node.vpath))
 				end
 				if path.isresourcefile(node.name) then


### PR DESCRIPTION
Hi Chris!

I've found a couple of minor bug in your codeblocks module that were avoiding to generate the proper scripts for my project:
- Pure C projects were ignored (only CPP projects were being processed)
- It was assuming that the source files were always located inside the project working directory

Please take a look at this pull request with the fixes for both bugs. And thank you very much for your work on this module, it was very useful for me!

Regards,

Ezequiel