### PR TITLE
Use `externalincludedirs` instead of deprecated `sysincludedirs`.

### DIFF
--- a/codeblocks_cbp.lua
+++ b/codeblocks_cbp.lua
@@ -138,8 +138,8 @@
 				for _, forceincludedir in ipairs(compiler.getforceincludes(cfg)) do
 					_p(5,'<Add option="%s" />', forceincludedir)
 				end
-				for _, sysincludedir in ipairs(compiler.getincludedirs(cfg, {}, cfg.sysincludedirs)) do
-					_p(5,'<Add option="%s" />', sysincludedir)
+				for _, externalincludedirs in ipairs(compiler.getincludedirs(cfg, {}, cfg.externalincludedirs)) do
+					_p(5,'<Add option="%s" />', externalincludedirs)
 				end
 				for _,v in ipairs(cfg.includedirs) do
 					_p(5,'<Add directory="%s" />', p.esc(path.getrelative(prj.location, v)))


### PR DESCRIPTION
Since Premake 5.0 beta2, [`sysincludedirs`](https://premake.github.io/docs/sysincludedirs/) has been deprecated in favor of [`externalincludedirs`](https://premake.github.io/docs/externalincludedirs).

That change allows to use the new API.
WARNING:
That change breaks the usage of (deprecated) `sysincludedirs` for Premake executable with version below 5.0 beta2.