### PR TITLE
Ignore project type of Utility

### DIFF
--- a/codeblocks.lua
+++ b/codeblocks.lua
@@ -42,6 +42,10 @@
 	end
 
 	function codeblocks.generateProject(prj)
+		--Kind "Utility" is not supported
+		if prj.kind == "Utility" then
+			return
+		end
 		p.eol("\r\n")
 		p.indent("\t")
 		p.escaper(codeblocks.esc)

--- a/codeblocks_workspace.lua
+++ b/codeblocks_workspace.lua
@@ -29,15 +29,18 @@
 		_p(1,'<Workspace title="%s">', wks.name)
 
 		for prj in workspace.eachproject(wks) do
-			local fname = path.join(path.getrelative(wks.location, prj.location), prj.name)
-			local active = iif(prj.project == wks.projects[1], ' active="1"', '')
+			--Kind "Utility" is not supported
+			if prj.kind ~= "Utility" then
+				local fname = path.join(path.getrelative(wks.location, prj.location), prj.name)
+				local active = iif(prj.project == wks.projects[1], ' active="1"', '')
 
-			_p(2,'<Project filename="%s.cbp"%s>', fname, active)
-			for _,dep in ipairs(project.getdependencies(prj)) do
-				_p(3,'<Depends filename="%s.cbp" />', path.join(path.getrelative(wks.location, dep.location), dep.name))
+				_p(2,'<Project filename="%s.cbp"%s>', fname, active)
+				for _,dep in ipairs(project.getdependencies(prj)) do
+					_p(3,'<Depends filename="%s.cbp" />', path.join(path.getrelative(wks.location, dep.location), dep.name))
+				end
+
+				_p(2,'</Project>')
 			end
-
-			_p(2,'</Project>')
 		end
 
 		_p(1,'</Workspace>')


### PR DESCRIPTION
Projects that are of [kind "Utility"](https://premake.github.io/docs/kind/#parameters) are not supported by CodeBlocks and with this patch are ignored by Premake.

This patch is to allow a [Youtube community learning project](https://github.com/TheCherno/Hazel) to work.