### PR TITLE
Replace `tbl.concat(tbl, " ")` by `table.concat(tbl, " ")`.

### DIFF
--- a/codeblocks_cbp.lua
+++ b/codeblocks_cbp.lua
@@ -35,7 +35,7 @@
 		local s = ""
 		for _, tbl in pairs(tableList) do
 			if #tbl > 0 then
-				s = s .. " " .. tbl.concat(tbl, " ")
+				s = s .. " " .. table.concat(tbl, " ")
 			end
 		end
 		return s


### PR DESCRIPTION
Last typo detected by my UTs.