### PR TITLE
[FIX] Replace deprecated/removed flags by dedicated API

### DIFF
--- a/codeblocks_auditor.lua
+++ b/codeblocks_auditor.lua
@@ -38,8 +38,8 @@
 			if filecfg1.buildaction ~= filecfg2.buildaction then
 				return false, "buildaction"
 			end
-			if filecfg1.flags.ExcludeFromBuild ~= filecfg2.flags.ExcludeFromBuild then
-				return false, 'flags {"ExcludeFromBuild"}'
+			if filecfg1.excludefrombuild ~= filecfg2.excludefrombuild then
+				return false, "excludefrombuild"
 			end
 			if filecfg1.buildmessage ~= filecfg2.buildmessage then
 				return false, "buildmessage"

--- a/codeblocks_cbp.lua
+++ b/codeblocks_cbp.lua
@@ -139,7 +139,7 @@
 
 				if (cfg.kind == "SharedLib") then
 					_p(4,'<Option createDefFile="0" />')
-					_p(4,'<Option createStaticLib="%s" />', iif(cfg.flags.NoImportLib, 0, 1))
+					_p(4,'<Option createStaticLib="%s" />', iif(cfg.useimportlib, 0, 1))
 				end
 
 				-- begin compiler block --
@@ -147,7 +147,7 @@
 				for _,flag in ipairs(table.join(compiler.getcflags(cfg), compiler.getcxxflags(cfg), compiler.getdefines(cfg.defines), compiler.getundefines(cfg.undefines), cfg.buildoptions)) do
 					_p(5,'<Add option="%s" />', p.esc(flag))
 				end
-				if not cfg.flags.NoPCH and cfg.pchheader then
+				if cfg.enablepch ~= p.OFF and cfg.pchheader then
 					_p(5,'<Add option="-Winvalid-pch" />')
 					_p(5,'<Add option="-include &quot;%s&quot;" />', p.esc(cfg.pchheader))
 				end
@@ -259,7 +259,7 @@
 				local filecfg = p.fileconfig.getconfig(node, cfg)
 				if path.isresourcefile(node.name) then
 					_p(3,'<Option compilerVar="WINDRES" />')
-				elseif filecfg.flags.ExcludeFromBuild or filecfg.buildaction == "None" then
+				elseif filecfg.excludefrombuild or filecfg.buildaction == "None" then
 					_p(3, '<Option compile="0" />')
 					_p(3, '<Option link="0" />')
 				elseif (node.compileas and node.compileas ~= "Default") or p.fileconfig.hasFileSettings(filecfg) then
@@ -279,7 +279,7 @@
 				elseif path.iscfile(node.name) and prj.language == "C++" then
 					_p(3,'<Option compilerVar="CC" />')
 				end
-				if not prj.flags.NoPCH and node.name == pchheader then
+				if prj.enablepch ~= p.OFF and node.name == pchheader then
 					_p(3,'<Option compilerVar="%s" />', iif(prj.language == "C", "CC", "CPP"))
 					_p(3,'<Option compile="1" />')
 					_p(3,'<Option weight="0" />')


### PR DESCRIPTION
As Premake removed `flags` in https://github.com/premake/premake-core/pull/2642
Tested with https://github.com/Jarod42/premake-sample-projects